### PR TITLE
feat: AppSettings Validation

### DIFF
--- a/Phasmophobia Wiki.sln.DotSettings
+++ b/Phasmophobia Wiki.sln.DotSettings
@@ -1,2 +1,3 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=appsettings/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Phasmophobia/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/Phasmophobia Wiki/Models/Activity.cs
+++ b/Phasmophobia Wiki/Models/Activity.cs
@@ -4,28 +4,29 @@ namespace Phasmophobia_Wiki.Models;
 
 /// <summary>
 /// Evidence a ghost will provide that assists in determining its type.
+/// Flag enum used to allow different combinations to be specified, without requiring a list.
 /// </summary>
 [Flags]
 public enum Activity
 {
     [Description("D.O.T.S Projector")]
-    Dots = 1 << 0,
+    Dots = 1 << 0, // 1
     
     [Description("EMF Level 5")]
-    Emf = 1 << 1,
+    Emf = 1 << 1, // 2
     
     [Description("Fingerprints")]
-    Fingerprints = 1 << 2,
+    Fingerprints = 1 << 2, // 4
     
     [Description("Freezing Temperatures")]
-    FreezingTemperatures = 1 << 3,
+    FreezingTemperatures = 1 << 3, // 8
     
     [Description("Ghost Orbs")]
-    GhostOrbs = 1 << 4,
+    GhostOrbs = 1 << 4, // 16
     
     [Description("Ghost Writing")]
-    GhostWriting = 1 << 5,
+    GhostWriting = 1 << 5, // 32
     
     [Description("Spirit Box")]
-    SpiritBox = 1 << 6
+    SpiritBox = 1 << 6 // 64
 }

--- a/Phasmophobia Wiki/Models/Settings.cs
+++ b/Phasmophobia Wiki/Models/Settings.cs
@@ -1,4 +1,6 @@
-﻿namespace Phasmophobia_Wiki.Models;
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace Phasmophobia_Wiki.Models;
 
 /// <summary>
 /// A list of settings defined within appsettings.json.
@@ -6,7 +8,17 @@
 public class Settings
 {
     /// <summary>
+    /// Used for identifying the correct appsettings section when binding on start-up.
+    /// </summary>
+    public const string SectionKey = "Settings";
+    
+    /// <summary>
     /// The file path of the 'Ghosts.json' file, containing a list of all ghosts in JSON format.
     /// </summary>
-    public string GhostsFilePath { get; set; }
+    [Required]
+    // ReSharper erroneously dictates this can be 'get-only', this cannot be bound in start-up without init or set, it also cannot be null as this is checked on start-up.
+    // ReSharper disable once AutoPropertyCanBeMadeGetOnly.Global
+#pragma warning disable CS8618
+    public string GhostsFilePath { get; init; }
+#pragma warning restore CS8618
 }

--- a/Phasmophobia Wiki/Pages/Index.cshtml.cs
+++ b/Phasmophobia Wiki/Pages/Index.cshtml.cs
@@ -5,22 +5,42 @@ using Phasmophobia_Wiki.Services;
 
 namespace Phasmophobia_Wiki.Pages;
 
+/// <summary>
+/// Main index page model.
+/// </summary>
 public class IndexModel : PageModel
 {
     private readonly IActivityService _activityService;
     private readonly HashSet<Ghost> _ghosts;
 
+    /// <summary>
+    /// Activities that the user has selected, used for determining what ghost types are possible.
+    /// </summary>
     [BindProperty]
     public Activity CheckedActivities { get; private set; }
     
+    /// <summary>
+    /// A list of ints that will be converted to the CheckedActivities above.
+    /// </summary>
     [BindProperty]
     public List<int> CheckedBoxes { get; set; } = new();
 
+    /// <summary>
+    /// All possible ghosts for the selected activities.
+    /// </summary>
     [BindProperty]
     public IEnumerable<Ghost> GhostsForActivities { get; private set; } = Enumerable.Empty<Ghost>();
     
+    /// <summary>
+    /// The 'friendly' descriptions for the Activity Enum values.
+    /// </summary>
     public List<string> ActivityEnumNames { get; private set; }
 
+    /// <summary>
+    /// Ctor.
+    /// </summary>
+    /// <param name="ghostService">Service level logic for getting ghosts.</param>
+    /// <param name="activityService">Service level logic for getting activities for ghosts.</param>
     public IndexModel(IGhostService ghostService, IActivityService activityService)
     {
         _ghosts = ghostService.Ghosts;
@@ -28,6 +48,10 @@ public class IndexModel : PageModel
         ActivityEnumNames = _activityService.ActivityDescriptors;
     }
 
+    /// <summary>
+    /// A post event made when a user specifies activities through the relevant checkboxes and presses 'Retrieve Possible Ghosts'.
+    /// Will result in all relevant ghosts being returned.
+    /// </summary>
     public void OnPost()
     {
         // If the user did not select any checkboxes before submitting, do not return any results:
@@ -36,12 +60,16 @@ public class IndexModel : PageModel
             return;
         }
 
-        // As flag enums are used, we can go through each checked item and perform (2 pow count) to get the flag enum combination:
+        // As flag enums are used, we can go through each checked item and perform (2 to the power count) to get the flag enum combination:
         CheckedActivities = (Activity) CheckedBoxes.Sum(checkboxValue => Math.Pow(2, checkboxValue));
         
+        // Get all ghosts for the selected activities.
         GhostsForActivities = _activityService.GetGhostsForActivities(CheckedActivities);
     }
 
+    /// <summary>
+    /// A post event made when the user selects 'List All Ghosts'.  Returns all possible ghosts.
+    /// </summary>
     public void OnPostAllGhosts()
     {
         GhostsForActivities = _ghosts;

--- a/Phasmophobia Wiki/Program.cs
+++ b/Phasmophobia Wiki/Program.cs
@@ -1,9 +1,7 @@
 using Microsoft.Net.Http.Headers;
-using Phasmophobia_Wiki.Models;
-using Phasmophobia_Wiki.Repositories;
-using Phasmophobia_Wiki.Services;
+using Phasmophobia_Wiki;
 
-var builder = WebApplication.CreateBuilder(args);
+WebApplicationBuilder builder = WebApplication.CreateBuilder(args);
 
 builder.Services.AddResponseCompression();
 
@@ -13,15 +11,11 @@ builder.WebHost.ConfigureKestrel(options =>
     options.ListenAnyIP(8000);
 });
 
-// Inject 'Settings'
-builder.Services.Configure<Settings>(builder.Configuration.GetSection("Settings"));
+// Inject and Validate 'Settings'.
+builder.Services.AddAndValidateSettings(builder.Configuration);
 
 // Add services to the DI container.
-builder.Services.AddSingleton<IGhostRepository, GhostRepository>();
-
-builder.Services.AddSingleton<IGhostService, GhostService>();
-
-builder.Services.AddSingleton<IActivityService, ActivityService>();
+builder.Services.AddPhasmophobiaWikiServices();
 
 builder.Services.AddRazorPages();
 

--- a/Phasmophobia Wiki/Repositories/GhostRepository.cs
+++ b/Phasmophobia Wiki/Repositories/GhostRepository.cs
@@ -16,6 +16,10 @@ public class GhostRepository : IGhostRepository
     /// </summary>
     private readonly string _filePath;
 
+    /// <summary>
+    /// Ctor.
+    /// </summary>
+    /// <param name="settings">Settings object containing the 'GhostsFilePath'.</param>
     public GhostRepository(IOptions<Settings> settings)
     {
         _filePath = settings.Value.GhostsFilePath;
@@ -27,14 +31,8 @@ public class GhostRepository : IGhostRepository
     /// <returns>A list of Ghosts.</returns>
     public HashSet<Ghost> GetGhosts()
     {
-        HashSet<Ghost>? ghosts = null;
-        
-        if (File.Exists(_filePath))
-        {
-            string json = File.ReadAllText(_filePath);
-            ghosts = JsonSerializer.Deserialize<HashSet<Ghost>>(json);    
-        }
-        
-        return ghosts ?? new HashSet<Ghost>();
+        string json = File.ReadAllText(_filePath);
+        HashSet<Ghost> ghosts = JsonSerializer.Deserialize<HashSet<Ghost>>(json)!;
+        return ghosts;
     }
 }

--- a/Phasmophobia Wiki/ServiceCollectionExtensions.cs
+++ b/Phasmophobia Wiki/ServiceCollectionExtensions.cs
@@ -1,0 +1,64 @@
+﻿using System.Text.Json;
+using Phasmophobia_Wiki.Models;
+using Phasmophobia_Wiki.Repositories;
+using Phasmophobia_Wiki.Services;
+
+// ReSharper disable InconsistentNaming
+namespace Phasmophobia_Wiki;
+
+/// <summary>
+/// Service collection logic.
+/// </summary>
+public static class ServiceCollectionExtensions
+{
+    /// <summary>
+    /// Adds and Validates the 'Settings' options on start-up, to ensure the application can function correctly.
+    /// The application will quit if validation fails.
+    /// </summary>
+    /// <param name="serviceCollection">Used for injecting the required Settings Options into the application.</param>
+    /// <param name="configuration">Used for obtaining the Settings section from within appsettings.</param>
+    public static void AddAndValidateSettings(this IServiceCollection serviceCollection, IConfiguration configuration)
+    {
+        serviceCollection.AddOptions<Settings>()
+            .Bind(configuration.GetRequiredSection(Settings.SectionKey)) // Ensure the 'Settings' section exists.
+            .ValidateDataAnnotations() // Validate that the 'GhostsFilePath' has been specified in appsettings.
+            .Validate(settings =>
+            {
+                // If validation logic returns true, validation was successful, otherwise it failed.
+                
+                if (settings is null || string.IsNullOrEmpty(settings.GhostsFilePath)) // Validate the Settings and GhostsFilePath contain values
+                {
+                    return false;
+                }
+
+                if (!settings.GhostsFilePath.EndsWith(".json", StringComparison.OrdinalIgnoreCase) || // Validate 'GhostsFilePath' is a JSON file and that it exists.
+                    !File.Exists(settings.GhostsFilePath))
+                {
+                    return false;
+                }
+
+                // Validate the JSON file contains at least 1 ghost:
+                string json = File.ReadAllText(settings.GhostsFilePath);
+                Ghost[]? ghosts = JsonSerializer.Deserialize<Ghost[]>(json);
+
+                if (ghosts is null || ghosts.Length == 0)
+                {
+                    throw new FileLoadException($"The file path {settings.GhostsFilePath} contains no ghosts.", settings.GhostsFilePath);
+                }
+
+                return true;
+            }) 
+            .ValidateOnStart();
+    }
+
+    /// <summary>
+    /// Adds the appropriate service and repository layers into the application.
+    /// </summary>
+    /// <param name="serviceCollection">Used for injecting the Service and Repository layers into the application through DI.</param>
+    public static void AddPhasmophobiaWikiServices(this IServiceCollection serviceCollection)
+    {
+        serviceCollection.AddSingleton<IGhostRepository, GhostRepository>();
+        serviceCollection.AddSingleton<IGhostService, GhostService>();
+        serviceCollection.AddSingleton<IActivityService, ActivityService>();
+    }
+}

--- a/Phasmophobia Wiki/appsettings.Development.json
+++ b/Phasmophobia Wiki/appsettings.Development.json
@@ -1,9 +1,0 @@
-{
-  "DetailedErrors": true,
-  "Logging": {
-    "LogLevel": {
-      "Default": "Information",
-      "Microsoft.AspNetCore": "Warning"
-    }
-  }
-}


### PR DESCRIPTION
The following has been added:

- Added appsettings to the 'shared wordlist'.
- Added comments to the flag enum for each value.
- Added section key to Settings model, along with requiring the GhostsFilePath and suppressing now redundant warnings.
- Added XML comments to IndexModel and GhostRepository constructor.
- Moved all service collection logic into ServiceCollectionExtensions.
- Added validation to the appsettings section for 'Settings' to ensure the program can function as intended.
- Removed duplicate validation from the repository layer.
- Removed appsettings development due to conflicts.